### PR TITLE
Bump Terraform to 1.3.1 to fix dependabot errors

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -65,10 +65,10 @@ runs:
           ${{ env.key_vault_app_secret_name }}
           ${{ env.key_vault_infra_secret_name }}
 
-    - name: Pin Terraform version
+    - name: Setup Terraform v1.3.1
       uses: hashicorp/setup-terraform@v2
       with:
-        terraform_version: 1.2.8
+        terraform_version: 1.3.1
 
     - name: Terraform init, Terraform Plan and Apply
       shell: bash

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Terraform v1.2.8
+      - name: Setup Terraform v1.3.1
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.2.8
+          terraform_version: 1.3.1
 
       - name: Set Environment variables
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,7 +2,7 @@ nodejs 16.14.0
 ruby 2.7.5
 yarn 1.22.18
 bundler 2.1.4
-terraform 1.2.8
+terraform 1.3.1
 cf 7.4.0
 az 2.36.0
 jq 1.6

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.2.8"
+  required_version = "~> 1.3.1"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
Bumping to 1.2.8 didn't work so moving to 1.3.1 which keeps the compatibility promise with 1.x

### Context

### Changes proposed in this pull request

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
